### PR TITLE
Fix: Android Gradle Plugin 8.x compatibility

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -25,6 +25,8 @@ apply plugin: 'com.android.library'
 apply plugin: 'kotlin-android'
 
 android {
+    namespace 'pl.pszklarska.beacon_broadcast'
+
     compileSdkVersion 28
 
     sourceSets {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -39,6 +39,13 @@ android {
     lintOptions {
         disable 'InvalidPackage'
     }
+    compileOptions {
+        sourceCompatibility JavaVersion.VERSION_17
+        targetCompatibility JavaVersion.VERSION_17
+    }
+    kotlinOptions {
+        jvmTarget = '17'
+    }
 }
 
 dependencies {

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -27,7 +27,7 @@ apply plugin: 'kotlin-android'
 android {
     namespace 'pl.pszklarska.beacon_broadcast'
 
-    compileSdkVersion 28
+    compileSdkVersion 30
 
     sourceSets {
         main.java.srcDirs += 'src/main/kotlin'

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,3 +1,2 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="pl.pszklarska.beacon_broadcast">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 </manifest>


### PR DESCRIPTION
- Added 'namespace' to build.gradle
- Removed deprecated 'package' attribute from AndroidManifest.xml
This fixes build failure on Flutter projects using AGP 8.0+